### PR TITLE
fix: remove unnecessary "|" or pipe char

### DIFF
--- a/models/coinItem.js
+++ b/models/coinItem.js
@@ -176,7 +176,7 @@ var CoinItem = GObject.registerClass(
           .map(({title, symbol}) => `${title || symbol} ...`).join(" | ");
 
       if (isInit)
-        newMenuItemText += ` | ${this.title || this.symbol} ...`
+        newMenuItemText += (newMenuItemText ? " | " : "") +`${this.title || this.symbol} ...`
 
       menuItem.text = newMenuItemText || "₿";
     }


### PR DESCRIPTION
Fix for the bug reported in #10.
This will remove unnecessary "|", if only one coin is enabled. 