### PR TITLE
feat: a button for opening charts

### DIFF
--- a/api/data.js
+++ b/api/data.js
@@ -16,7 +16,7 @@ var change_exchange = (exchange_name) => {
 };
 
 var get_exchange = () => {
-  if (current_exchange != '') return current_exchange;
+  if (current_exchange !== '') return current_exchange;
   current_exchange = Settings.get_exchange();
   return current_exchange;
 };
@@ -41,11 +41,8 @@ async function _getPriceFromBinance(name, vol) {
 
     let price = +jsonRes.price;
 
-    let maximumFractionDigits = 0;
-    const dig_count = price.toFixed().length;
-    if (5 - dig_count > 0) maximumFractionDigits = 5 - dig_count;
-
-    return price.toLocaleString(undefined, { maximumFractionDigits });
+    let { maximumFractionDigits, minimumFractionDigits } = _fractionDigits(price);
+    return price.toLocaleString(undefined, { maximumFractionDigits, minimumFractionDigits });
   } catch (error) {}
 }
 
@@ -56,10 +53,33 @@ async function _getPriceFromOKX(name, vol) {
 
     const jsonRes = JSON.parse(res.body);
 
-    if (jsonRes.data.length == 0) return -1;
+    if (jsonRes.data.length === 0) return -1;
 
     let price = +jsonRes.data[0].last;
 
-    return price.toLocaleString();
+    let { maximumFractionDigits, minimumFractionDigits } = _fractionDigits(price);
+    return price.toLocaleString(undefined, { maximumFractionDigits, minimumFractionDigits });
   } catch (error) {}
+}
+
+function _fractionDigits(price) {
+
+  let maximumFractionDigits = 0;
+  let minimumFractionDigits = 0;
+
+  if (price < 100 && price >= 10) {
+    maximumFractionDigits = 2
+    minimumFractionDigits = 2
+  } else if (price < 10 && price >= 1) {
+    maximumFractionDigits = 3
+    minimumFractionDigits = 3
+  } else if (price < 1 && price >= .1) {
+    maximumFractionDigits = 4
+    minimumFractionDigits = 4
+  } else if (price < .1) {
+    maximumFractionDigits = 5
+    minimumFractionDigits = 5
+  }
+
+  return { maximumFractionDigits, minimumFractionDigits };
 }

--- a/models/coinItem.js
+++ b/models/coinItem.js
@@ -1,9 +1,5 @@
-const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
-const St = imports.gi.St;
-const Clutter = imports.gi.Clutter;
-const Signals = imports.signals;
-const Atk = imports.gi.Atk;
+// noinspection DuplicatedCode
+const { Atk, Clutter, Gtk, GLib, GObject, St } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -31,6 +27,46 @@ var CoinItem = GObject.registerClass(
       this.accessible_role = Atk.Role.CHECK_MENU_ITEM;
       this.checkAccessibleState();
 
+      let viewIcon = new St.Icon({
+        icon_name: 'external-link-symbolic',
+        style_class: 'popup-menu-icon',
+      });
+      let viewBtn = new St.Button({
+        child: viewIcon,
+        style_class: 'btn m0',
+      });
+      viewBtn.connect('clicked', this._openChart.bind(this));
+      this.add_child(viewBtn);
+
+      this.nameLbl = new St.Label({
+        text: title || symbol,
+        style_class: "itemLabel",
+        y_align: Clutter.ActorAlign.CENTER,
+      });
+      this.add_child(this.nameLbl);
+
+      this.priceLbl = new St.Label({
+        text: "...",
+        style_class: 'itemLabel text-align-right',
+        y_align: Clutter.ActorAlign.CENTER,
+      });
+      this.add_child(this.priceLbl);
+
+      let expander = new St.Bin({
+        style_class: 'popup-menu-item-expander',
+        x_expand: true,
+      });
+      this.add_child(expander);
+
+      this._statusBtn = new St.Button({
+        x_align: Clutter.ActorAlign.START,
+        // x_expand: true,
+        child: this._switch
+      });
+      this._statusBtn.connect('clicked', this._toggle.bind(this, menuItem));
+      this.add_child(this._statusBtn);
+      // this._statusBin.child = this._switch;
+
       let icon = new St.Icon({
         icon_name: 'edit-delete-symbolic',
         style_class: 'popup-menu-icon',
@@ -42,27 +78,6 @@ var CoinItem = GObject.registerClass(
       delBtn.connect('clicked', this._delCoin.bind(this));
       this.add_child(delBtn);
 
-      this.label = new St.Label({
-        text: title || symbol,
-        y_expand: true,
-        y_align: Clutter.ActorAlign.CENTER,
-      });
-      this.add_child(this.label);
-
-      let expander = new St.Bin({
-        style_class: 'popup-menu-item-expander',
-        x_expand: true,
-      });
-      this.add_child(expander);
-
-      this._statusBin = new St.Bin({
-        // x_align: Clutter.ActorAlign.END,
-        // x_expand: true,
-      });
-      this.add_child(this._statusBin);
-      this._statusBin.child = this._switch;
-
-      // this.text = text;
       this.symbol = symbol;
       this.activeCoin = active;
       this.title = title;
@@ -71,8 +86,6 @@ var CoinItem = GObject.registerClass(
 
       if (active) this._activeCoin(menuItem, true);
       this._startTimer(menuItem);
-
-      this.connect('toggled', this.toggleCoin.bind(this, menuItem));
     }
     _activeCoin(menuItem, isInit) {
       this.activeCoin = true;
@@ -120,12 +133,12 @@ var CoinItem = GObject.registerClass(
               ') ((\\.\\.\\.)|(\\d*(,?\\d\\d\\d)*|\\d+)(\\.?\\d*))?',
             'g'
           );
-          menuItem.text = menuItem.text.replace(
-            re,
-            `${this.title || this.symbol} ${price}`
+          let menuPairPrice = isNaN(price.replaceAll(",","")) ? "..." : price;
+          menuItem.text = menuItem.text.replace(re, `${this.title || this.symbol} ${menuPairPrice}`
           );
         }
-        this.label.text = `${this.title || this.symbol}    ${price}     `;
+        this.nameLbl.text = `${this.title || this.symbol}`;
+        this.priceLbl.text = `${price}`;
       } catch (error) {}
     }
     get state() {
@@ -137,22 +150,22 @@ var CoinItem = GObject.registerClass(
     }
 
     activate(event) {
-      if (this._switch.mapped) this.toggle();
+      if (this._switch.mapped) return;
 
       // we allow pressing space to toggle the switch
       // without closing the menu
       if (
-        event.type() == Clutter.EventType.KEY_PRESS &&
-        event.get_key_symbol() == Clutter.KEY_space
+        event.type() === Clutter.EventType.KEY_PRESS &&
+        event.get_key_symbol() === Clutter.KEY_space
       )
         return;
 
       super.activate(event);
     }
 
-    toggle() {
+    _toggle(menu) {
       this._switch.toggle();
-      this.emit('toggled', this._switch.state);
+      this.toggleCoin(menu);
       this.checkAccessibleState();
     }
 
@@ -181,8 +194,9 @@ var CoinItem = GObject.registerClass(
     }
 
     _updateMenuCoinItems(menuItem, isInit) {
-      let newMenuItemText = this.coins
-        .filter(({ activeCoin }) => activeCoin)
+      let activeCoins = this.coins
+          .filter(({ activeCoin }) => activeCoin);
+      let newMenuItemText = activeCoins
         .map(({ title, symbol }) => `${title || symbol} ...`)
         .join(' | ');
 
@@ -191,11 +205,27 @@ var CoinItem = GObject.registerClass(
           (newMenuItemText ? ' | ' : '') + `${this.title || this.symbol} ...`;
 
       menuItem.text = newMenuItemText || '₿';
+
+      if (!isInit)
+        activeCoins.forEach((coin) => coin._refreshPrice(menuItem));
     }
 
     _delCoin() {
       Settings.delCoin({ symbol: this.symbol });
       this.destroy();
+    }
+
+    _openChart() {
+      try {
+        let exchangeUrl = Data.get_exchange() === Data.exchanges.okx ? "https://www.okx.com/markets/spot-info/" : "https://www.binance.com/en/trade/";
+        let pair = Data.get_exchange() === Data.exchanges.okx ? this.symbol.replace('/', '-').toLowerCase() : this.symbol.replace('/', '_').toUpperCase();
+
+        Gtk.show_uri(null, exchangeUrl + pair, global.get_current_time());
+      }
+      catch (err) {
+        let title = _("Can not open %s").format(url);
+        Main.notifyError(title, err);
+      }
     }
 
     destroy() {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -55,6 +55,14 @@
   /* width: 100%; */
 }
 
+.itemLabel {
+  min-width: 60px;
+}
+
+.text-align-right {
+  text-align: right;
+}
+
 .color {
   background-color: red;
 }


### PR DESCRIPTION
resolves #14 

Changes:
* Updated the layout of the CoinItem (see screenshot below)
* New button for opening charts
* Toggling status will only work in the Switch button


Additional changes:
* For Altcoins, it can now display up to 5 decimal points 
* When toggling, all the active pairs will now load the prices immediately 


Screenshot:
![image](https://user-images.githubusercontent.com/12295737/199820869-6d2fa6f8-515a-4eea-b350-f0b1e71d7339.png)

![image](https://user-images.githubusercontent.com/12295737/199820788-b42d9248-346d-46a6-8447-5cfb7b267d48.png)
