### PR TITLE
fix: remove Gtk from imports

### DIFF
--- a/models/coinItem.js
+++ b/models/coinItem.js
@@ -1,5 +1,5 @@
 // noinspection DuplicatedCode
-const { Atk, Clutter, Gtk, GLib, GObject, St } = imports.gi;
+const { Atk, Clutter, GLib, GObject, St } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -8,6 +8,7 @@ const Data = Me.imports.api.data;
 const Settings = Me.imports.settings;
 
 const PopupMenu = imports.ui.popupMenu;
+const Util = imports.misc.util;
 
 var CoinItem = GObject.registerClass(
   {
@@ -233,7 +234,7 @@ var CoinItem = GObject.registerClass(
             ? this.symbol.replace('/', '-').toLowerCase()
             : this.symbol.replace('/', '_').toUpperCase();
 
-        Gtk.show_uri(null, exchangeUrl + pair, global.get_current_time());
+        Util.spawnCommandLine(`xdg-open ${exchangeUrl + pair}`);
       } catch (err) {
         let title = _('Can not open %s').format(url);
         Main.notifyError(title, err);


### PR DESCRIPTION
This is a fix for the review comment from https://extensions.gnome.org/review/36250.
```
You shouldn't import gtk in GNOME Shell (line 2 and 236 models/coinItem.js)
You can use [shell.appsystem](https://gjs-docs.gnome.org/shell01~0.1_api/shell.appsystem) or spawn command `xdg-open URL` instead.
```
The issue was introduced from #15 