### PR TITLE
Gnome 46 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ const Indicator = GObject.registerClass(
         St.PolicyType.NEVER,
         St.PolicyType.AUTOMATIC
       );
-      this._coinsScrollview.add_actor(this.coinsScrollViewVbox);
+      this._coinsScrollview.add_child(this.coinsScrollViewVbox);
       baseMenuItem.add_child(this._coinsScrollview);
     }
 

--- a/models/addCoinMenuItem.js
+++ b/models/addCoinMenuItem.js
@@ -28,10 +28,10 @@ export let AddCoinMenuItem = GObject.registerClass(
       this.actor.add_child(vbox);
 
       let sourceBoxLayout = new AddCoinSourceBoxLayout(this);
-      vbox.add(sourceBoxLayout);
+      vbox.add_child(sourceBoxLayout);
 
       let hbox = new St.BoxLayout({ x_expand: true });
-      vbox.add(hbox);
+      vbox.add_child(hbox);
 
       let coinSymbol = new St.Entry({
         name: 'symbol',
@@ -40,7 +40,7 @@ export let AddCoinMenuItem = GObject.registerClass(
         x_expand: true,
         style_class: 'crypto-input',
       });
-      hbox.add(coinSymbol);
+      hbox.add_child(coinSymbol);
 
       let coinTitle = new St.Entry({
         name: 'title',
@@ -49,7 +49,7 @@ export let AddCoinMenuItem = GObject.registerClass(
         x_expand: true,
         style_class: 'crypto-input',
       });
-      hbox.add(coinTitle);
+      hbox.add_child(coinTitle);
 
       let saveIcon = new St.Icon({
         icon_name: 'media-floppy-symbolic',
@@ -63,7 +63,7 @@ export let AddCoinMenuItem = GObject.registerClass(
         'clicked',
         this._addCoin.bind(this, coinSymbol, coinTitle)
       );
-      hbox.add(addBtn);
+      hbox.add_child(addBtn);
     }
 
     async _addCoin(coinSymbol, coinTitle) {

--- a/models/addCoinSourceBoxLayout.js
+++ b/models/addCoinSourceBoxLayout.js
@@ -55,7 +55,7 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         if (this.isActiveChangeSource) {
           this.add_child(this._scrollView);
         } else {
-          this.remove_actor(this._scrollView)
+          this.remove_child(this._scrollView)
         }
       });
 

--- a/models/addCoinSourceBoxLayout.js
+++ b/models/addCoinSourceBoxLayout.js
@@ -17,20 +17,20 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         x_expand: true,
         style_class: 'exchange-hbox',
       });
-      this.add(hbox);
+      this.add_child(hbox);
 
       this.sourceLbl = new St.Label({
         text: ('%s %s').format('Source: ', this.addCoinMenuItem.current_exchange),
         y_align: Clutter.ActorAlign.CENTER,
         style_class: 'crypto-label',
       });
-      hbox.add(this.sourceLbl);
+      hbox.add_child(this.sourceLbl);
 
       let expander = new St.Bin({
         style_class: 'popup-menu-item-expander',
         x_expand: true,
       });
-      hbox.add(expander);
+      hbox.add_child(expander);
 
       let changeSourceHbox = new St.BoxLayout({
         x_expand: true,
@@ -40,20 +40,20 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         icon_name: 'go-next-symbolic',
         style_class: 'popup-menu-icon',
       });
-      changeSourceHbox.add(this.changeSourceIcon);
+      changeSourceHbox.add_child(this.changeSourceIcon);
 
       let changeSourceBtn = new St.Button({
         child: changeSourceHbox,
         style_class: 'crypto-input btn',
       });
-      hbox.add(changeSourceBtn);
+      hbox.add_child(changeSourceBtn);
 
       this.isActiveChangeSource = false;
       changeSourceBtn.connect('clicked', (self) => {
         this.isActiveChangeSource = !this.isActiveChangeSource;
         this.changeSourceIcon.icon_name = (this.isActiveChangeSource) ? 'go-down-symbolic' : 'go-next-symbolic';
         if (this.isActiveChangeSource) {
-          this.add_actor(this._scrollView);
+          this.add_child(this._scrollView);
         } else {
           this.remove_actor(this._scrollView)
         }
@@ -70,7 +70,7 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         height: 80,
       });
       this._scrollView.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
-      this._scrollView.add_actor(this.sourceSection);
+      this._scrollView.add_child(this.sourceSection);
       this._buildSourceButtons();
     }
 
@@ -82,7 +82,7 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
           sourceBtnsHbox = new St.BoxLayout({
             x_expand: true,
           });
-          this.sourceSection.add(sourceBtnsHbox);
+          this.sourceSection.add_child(sourceBtnsHbox);
         }
 
         let exchangeBtnHbox = new St.BoxLayout({
@@ -92,13 +92,13 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         let exchangeIco = new St.Icon({
           style_class: `popup-menu-icon exchange-icon ${val.toLowerCase()}`,
         });
-        exchangeBtnHbox.add(exchangeIco);
+        exchangeBtnHbox.add_child(exchangeIco);
 
         let exchangeLbl = new St.Label({
           text: `${val}`,
           style_class: 'crypto-label',
         });
-        exchangeBtnHbox.add(exchangeLbl);
+        exchangeBtnHbox.add_child(exchangeLbl);
 
         let btn = new St.Button({
           child: exchangeBtnHbox,
@@ -121,7 +121,7 @@ export let AddCoinSourceBoxLayout = GObject.registerClass(
         });
 
         btns.push(btn);
-        sourceBtnsHbox.add(btn);
+        sourceBtnsHbox.add_child(btn);
       }
     }
   }


### PR DESCRIPTION
Its a related change of gnome 46

## Clutter.Container
```Clutter.Container``` was removed.

[Clutter.Container.add_actor()](https://gjs-docs.gnome.org/clutter13~13/clutter.container#method-add_actor) and [Clutter.Container.remove_actor()](https://gjs-docs.gnome.org/clutter13~13/clutter.container#method-remove_actor) are deprecated and you should use [Clutter.Actor.add_child()](https://gjs-docs.gnome.org/clutter13~13/clutter.actor#method-add_child) and [Clutter.Actor.remove_child()](https://gjs-docs.gnome.org/clutter13~13/clutter.actor#method-remove_child) instead.

So, instead of actor-added and actor-removed signals you can use child-added and child-removed